### PR TITLE
Fix build on Travis #50

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 install: 
 - mvn install -P !build-extras -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script: mvn test -P !build-extras -B
-jdk: oraclejdk8
+jdk: openjdk8
 cache:
   directories:
   - "$HOME/.m2"


### PR DESCRIPTION
oracleJDK8 is no more available, use openJDK8

Signed-off-by: Aurélien Pupier <apupier@redhat.com>