### PR TITLE
FUSETOOLS2-191 - Upgrade from Camel 3.0.1 to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<slf4j.version>1.7.6</slf4j.version>
 		<junit.version>5.6.0</junit.version>
 		<assertj.version>3.15.0</assertj.version>
-		<camel.version>3.0.1</camel.version>
+		<camel.version>3.1.0</camel.version>
 	</properties>
 
 	<distributionManagement>

--- a/src/main/java/com/github/cameltooling/model/ComponentModel.java
+++ b/src/main/java/com/github/cameltooling/model/ComponentModel.java
@@ -29,9 +29,9 @@ public class ComponentModel {
     private String title;
     private String description;
     private String label;
-    private String deprecated;
-    private String consumerOnly;
-    private String producerOnly;
+    private boolean deprecated;
+    private boolean consumerOnly;
+    private boolean producerOnly;
     private String javaType;
     private String groupId;
     private String artifactId;
@@ -103,27 +103,27 @@ public class ComponentModel {
         this.label = label;
     }
 
-    public String getDeprecated() {
+    public boolean getDeprecated() {
         return deprecated;
     }
 
-    public void setDeprecated(String deprecated) {
+    public void setDeprecated(boolean deprecated) {
         this.deprecated = deprecated;
     }
 
-    public String getConsumerOnly() {
+    public boolean getConsumerOnly() {
         return consumerOnly;
     }
 
-    public void setConsumerOnly(String consumerOnly) {
-        this.consumerOnly = consumerOnly;
+    public void setConsumerOnly(boolean b) {
+        this.consumerOnly = b;
     }
 
-    public String getProducerOnly() {
+    public boolean getProducerOnly() {
         return producerOnly;
     }
 
-    public void setProducerOnly(String producerOnly) {
+    public void setProducerOnly(boolean producerOnly) {
         this.producerOnly = producerOnly;
     }
 

--- a/src/main/java/com/github/cameltooling/model/ComponentOptionModel.java
+++ b/src/main/java/com/github/cameltooling/model/ComponentOptionModel.java
@@ -16,19 +16,21 @@
  */
 package com.github.cameltooling.model;
 
+import java.util.List;
+
 public class ComponentOptionModel {
 
     private String name;
     private String kind;
     private String group;
-    private String required;
+    private boolean required;
     private String type;
     private String javaType;
-    private String deprecated;
-    private String secret;
+    private boolean deprecated;
+    private boolean secret;
     private String description;
-    private String defaultValue;
-    private String enums;
+    private Object defaultValue;
+    private List<String> enums;
 
     public String getName() {
         return name;
@@ -54,11 +56,11 @@ public class ComponentOptionModel {
         this.group = group;
     }
 
-    public String getRequired() {
+    public boolean getRequired() {
         return required;
     }
 
-    public void setRequired(String required) {
+    public void setRequired(boolean required) {
         this.required = required;
     }
 
@@ -78,19 +80,19 @@ public class ComponentOptionModel {
         this.javaType = javaType;
     }
 
-    public String getDeprecated() {
+    public boolean getDeprecated() {
         return deprecated;
     }
 
-    public void setDeprecated(String deprecated) {
+    public void setDeprecated(boolean deprecated) {
         this.deprecated = deprecated;
     }
 
-    public String getSecret() {
+    public boolean getSecret() {
         return secret;
     }
 
-    public void setSecret(String secret) {
+    public void setSecret(boolean secret) {
         this.secret = secret;
     }
 
@@ -102,19 +104,19 @@ public class ComponentOptionModel {
         this.description = description;
     }
 
-    public String getDefaultValue() {
+    public Object getDefaultValue() {
         return defaultValue;
     }
 
-    public void setDefaultValue(String defaultValue) {
+    public void setDefaultValue(Object defaultValue) {
         this.defaultValue = defaultValue;
     }
 
-    public String getEnums() {
+    public List<String> getEnums() {
         return enums;
     }
 
-    public void setEnums(String enums) {
+    public void setEnums(List<String> enums) {
         this.enums = enums;
     }
 

--- a/src/main/java/com/github/cameltooling/model/EndpointOptionModel.java
+++ b/src/main/java/com/github/cameltooling/model/EndpointOptionModel.java
@@ -16,21 +16,23 @@
  */
 package com.github.cameltooling.model;
 
+import java.util.List;
+
 public class EndpointOptionModel {
 
     private String name;
     private String kind;
     private String group;
     private String label;
-    private String required;
+    private boolean required;
     private String type;
     private String javaType;
-    private String enums;
+    private List<String> enums;
     private String prefix;
-    private String multiValue;
-    private String deprecated;
-    private String secret;
-    private String defaultValue;
+    private boolean multiValue;
+    private boolean deprecated;
+    private boolean secret;
+    private Object defaultValue;
     private String description;
     private String enumValues;
 
@@ -66,11 +68,11 @@ public class EndpointOptionModel {
         this.label = label;
     }
 
-    public String getRequired() {
+    public boolean getRequired() {
         return required;
     }
 
-    public void setRequired(String required) {
+    public void setRequired(boolean required) {
         this.required = required;
     }
 
@@ -90,11 +92,11 @@ public class EndpointOptionModel {
         this.javaType = javaType;
     }
 
-    public String getEnums() {
+    public List<String> getEnums() {
         return enums;
     }
 
-    public void setEnums(String enums) {
+    public void setEnums(List<String> enums) {
         this.enums = enums;
     }
 
@@ -106,35 +108,35 @@ public class EndpointOptionModel {
         this.prefix = prefix;
     }
 
-    public String getMultiValue() {
+    public boolean getMultiValue() {
         return multiValue;
     }
 
-    public void setMultiValue(String multiValue) {
+    public void setMultiValue(boolean multiValue) {
         this.multiValue = multiValue;
     }
 
-    public String getDeprecated() {
+    public boolean getDeprecated() {
         return deprecated;
     }
 
-    public void setDeprecated(String deprecated) {
+    public void setDeprecated(boolean deprecated) {
         this.deprecated = deprecated;
     }
 
-    public String getSecret() {
+    public boolean getSecret() {
         return secret;
     }
 
-    public void setSecret(String secret) {
+    public void setSecret(boolean secret) {
         this.secret = secret;
     }
 
-    public String getDefaultValue() {
+    public Object getDefaultValue() {
         return defaultValue;
     }
 
-    public void setDefaultValue(String defaultValue) {
+    public void setDefaultValue(Object defaultValue) {
         this.defaultValue = defaultValue;
     }
 


### PR DESCRIPTION
- JSonSchemahelper has been removed
- needs to use camel-json-util to replace it
- provide more precised typing to match new camel-json-util

Signed-off-by: Aurélien Pupier <apupier@redhat.com>