### PR TITLE
FUSETOOLS2-256 - launch test before using Sonar analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ after_success:
   export IS_SNAPSHOT=false;
  fi
 - if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $IS_SNAPSHOT == "true" || -n "$TRAVIS_TAG" && $IS_SNAPSHOT == "false" ]]; then 
-  mvn sonar:sonar -Dsonar.login=${SONAR_TOKEN} -Dsonar.projectKey="camel-tooling-common" -Dsonar.projectName="Camel Tooling Common";
+  mvn verfiy sonar:sonar -Dsonar.login=${SONAR_TOKEN} -Dsonar.projectKey="camel-tooling-common" -Dsonar.projectName="Camel Tooling Common";
  fi
 - if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $IS_SNAPSHOT == "true" ]]; then
  ./cd/before-deploy.sh;


### PR DESCRIPTION
previously it was configured to launch it automatically which is not the
common way to do it. COnsequently, by following conventions we need to
specify to laucnh the build and tests before using Sonar Analysis to
have code coverage

Signed-off-by: Aurélien Pupier <apupier@redhat.com>